### PR TITLE
Freeing WTF::comSunWebkitFileSystem

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.cpp
@@ -148,6 +148,8 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
 
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* , void*)
 {
+    delete WTF::comSunWebkitFileSystem;
+    WTF::comSunWebkitFileSystem = 0;
 #if PLATFORM(JAVA_WIN) && !defined(NDEBUG)
     _CrtDumpMemoryLeaks();
 #endif


### PR DESCRIPTION
Matthias, you may want to propose this as well, so WTF::comSunWebkitFileSystem  does not hold any reference and the JVM GC can continue GC'ing the classloader.